### PR TITLE
Hack to work around xf86ModeStatusToString removal from public headers

### DIFF
--- a/src/via_display.c
+++ b/src/via_display.c
@@ -3195,6 +3195,10 @@ via_crtc_unlock(xf86CrtcPtr crtc)
                         "Exiting %s.\n", __func__));
 }
 
+/* HACK: Copied prototype from xf86_priv.h */
+_X_EXPORT /* only for int10 module, not supposed to be used by OOT modules */
+const char * xf86ModeStatusToString(ModeStatus status);
+
 static Bool
 via_crtc_mode_fixup(xf86CrtcPtr crtc, DisplayModePtr mode,
                         DisplayModePtr adjusted_mode)


### PR DESCRIPTION
src/via_display.c (xf86ModeStatusToString): HACK: Copy the prototype for this function from xf86_priv.h. It is used in a log message in via_crtc_mode_fixup. This makes it compile for now.

TODO: In the long run, either this function should be moved back to the public headers in xserver, or the driver should stop using it (but then the log message will be less informative).