### PR TITLE
Use xf86newOption instead of the removed xf86NewOption

### DIFF
--- a/src/via_driver.c
+++ b/src/via_driver.c
@@ -1125,7 +1125,7 @@ VIAPreInit(ScrnInfoPtr pScrn, int flags)
     }
 #endif /* OPENCHROMEDRI */
 
-    option = xf86NewOption(strEXAOptionName, strEXAValue);
+    option = xf86newOption(strEXAOptionName, strEXAValue);
     xf86CollectOptions(pScrn, option);
 
     viaSetupDefaultOptions(pScrn);


### PR DESCRIPTION
src/via_driver.c (VIAPreInit): Use xf86newOption instead of the removed xf86NewOption alias. Fixes the build.