### PR TITLE
configure.ac: Disable XVMC support, does not compile (#6)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,10 +166,11 @@ if test "$DRI" = yes; then
     CFLAGS="$save_CFLAGS"
 
     case "$host_cpu" in
-        i*86)
-            XVMC=yes ;;
-        amd64*|x86_64*)
-            XVMC=yes ;;
+# FIXME: XVMC support disabled because it does not compile (see issue #6)
+#        i*86)
+#            XVMC=yes ;;
+#        amd64*|x86_64*)
+#            XVMC=yes ;;
         *)
             XVMC=no ;;
     esac


### PR DESCRIPTION
Comment out the lines enabling XVMC for x86 architectures. It currently does not compile. It depends on at least one private header ("xf86xvpriv.h") that is not installed by XLibre. It turns out that Fedora has not been compiling this part of the driver since 2021, by simply not installing the build dependencies for it.

Fixes #6.