### PR TITLE
drop #ifdef RANDR_13_INTERFACE

### DIFF
--- a/src/via_analog.c
+++ b/src/via_analog.c
@@ -457,13 +457,11 @@ via_analog_set_property(xf86OutputPtr output, Atom property,
     return TRUE;
 }
 
-#ifdef RANDR_13_INTERFACE
 static Bool
 via_analog_get_property(xf86OutputPtr output, Atom property)
 {
     return FALSE;
 }
-#endif
 
 static void
 via_analog_destroy(xf86OutputPtr output)
@@ -483,9 +481,7 @@ static const xf86OutputFuncsRec via_analog_funcs = {
     .detect             = via_analog_detect,
     .get_modes          = via_analog_get_modes,
     .set_property       = via_analog_set_property,
-#ifdef RANDR_13_INTERFACE
     .get_property       = via_analog_get_property,
-#endif
     .destroy            = via_analog_destroy,
 };
 

--- a/src/via_fp.c
+++ b/src/via_fp.c
@@ -1158,9 +1158,7 @@ static const xf86OutputFuncsRec via_fp_funcs = {
     .detect             = via_fp_detect,
     .get_modes          = via_fp_get_modes,
     .set_property       = via_fp_set_property,
-#ifdef RANDR_13_INTERFACE
     .get_property       = via_fp_get_property,
-#endif
     .destroy            = via_fp_destroy
 };
 

--- a/src/via_sii164.c
+++ b/src/via_sii164.c
@@ -400,13 +400,11 @@ via_sii164_set_property(xf86OutputPtr output, Atom property,
     return TRUE;
 }
 
-#ifdef RANDR_13_INTERFACE
 static Bool
 via_sii164_get_property(xf86OutputPtr output, Atom property)
 {
     return FALSE;
 }
-#endif
 
 static void
 via_sii164_destroy(xf86OutputPtr output)
@@ -426,9 +424,7 @@ const xf86OutputFuncsRec via_sii164_funcs = {
     .detect             = via_sii164_detect,
     .get_modes          = via_sii164_get_modes,
     .set_property       = via_sii164_set_property,
-#ifdef RANDR_13_INTERFACE
     .get_property       = via_sii164_get_property,
-#endif
     .destroy            = via_sii164_destroy,
 };
 

--- a/src/via_tmds.c
+++ b/src/via_tmds.c
@@ -587,7 +587,6 @@ via_tmds_set_property(xf86OutputPtr output, Atom property,
     return TRUE;
 }
 
-#ifdef RANDR_13_INTERFACE
 static Bool
 via_tmds_get_property(xf86OutputPtr output, Atom property)
 {
@@ -602,7 +601,6 @@ via_tmds_get_property(xf86OutputPtr output, Atom property)
                         "Exiting via_tmds_get_property.\n"));
     return FALSE;
 }
-#endif
 
 static void
 via_tmds_destroy(xf86OutputPtr output)
@@ -637,9 +635,7 @@ static const xf86OutputFuncsRec via_tmds_funcs = {
     .detect             = via_tmds_detect,
     .get_modes          = xf86OutputGetEDIDModes,
     .set_property       = via_tmds_set_property,
-#ifdef RANDR_13_INTERFACE
     .get_property       = via_tmds_get_property,
-#endif
     .destroy            = via_tmds_destroy,
 };
 

--- a/src/via_tv.c
+++ b/src/via_tv.c
@@ -731,9 +731,7 @@ via_tv_destroy(xf86OutputPtr output)
 static const xf86OutputFuncsRec via_tv_funcs = {
     .create_resources   = via_tv_create_resources,
     .set_property       = via_tv_set_property,
-#ifdef RANDR_13_INTERFACE
     .get_property       = via_tv_get_property,
-#endif
     .dpms               = via_tv_dpms,
     .save               = via_tv_save,
     .restore            = via_tv_restore,

--- a/src/via_vt1632.c
+++ b/src/via_vt1632.c
@@ -438,9 +438,7 @@ const xf86OutputFuncsRec via_vt1632_funcs = {
     .detect             = via_vt1632_detect,
     .get_modes          = via_vt1632_get_modes,
     .set_property       = via_vt1632_set_property,
-#ifdef RANDR_13_INTERFACE
     .get_property       = via_vt1632_get_property,
-#endif
     .destroy            = via_vt1632_destroy,
 };
 


### PR DESCRIPTION
All (non-ancient) Xservers always have it.